### PR TITLE
[심민보] 같은 숫자는 싫어

### DIFF
--- a/스택,큐/같은 숫자는 싫어(시간 초과).js
+++ b/스택,큐/같은 숫자는 싫어(시간 초과).js
@@ -1,0 +1,13 @@
+function solution(arr)
+{
+    var answer = [];
+    for(let i of arr) {
+        if(answer.at(-1) != i) {
+            answer.push(i)
+        }
+    }
+    return answer;
+}
+
+console.log(solution([1,1,3,3,0,1,1]));
+console.log(solution([4,4,4,3,3]));

--- a/스택,큐/같은 숫자는 싫어.js
+++ b/스택,큐/같은 숫자는 싫어.js
@@ -1,0 +1,12 @@
+function solution(arr)
+{
+  let answer = [];
+  for(let i = 0; i < arr.length; i++) {
+      if(arr[i] !== arr[i + 1]) {
+          answer.push(arr[i]);
+      }
+  }
+  return answer;
+}
+
+console.log(solution([1,1,3,3,0,1,1]));

--- a/스택,큐/기능 개발.js
+++ b/스택,큐/기능 개발.js
@@ -1,0 +1,28 @@
+function solution(progresses, speeds) {
+  let answer = [];
+  for(let i = 0; i < progresses.length; i++) {
+    let sum = progresses[i];
+    let count = 0;
+    while(sum < 100) {
+      sum += speeds[i];
+      count++;
+    }
+    answer.push(count);
+  }
+  let count = 1;
+  let correct = [];
+  let max = answer[0];
+  for(let i = 1; i < answer.length; i++) {
+    if(answer[i] <= max) {
+      count++;
+    } else {
+      correct.push(count);
+      count = 1;
+      max = answer[i];
+    }
+  }
+  correct.push(count);
+  return correct;
+}
+
+console.log(solution([93, 30, 55], 	[1, 30, 5]));

--- a/정렬/H-index.js
+++ b/정렬/H-index.js
@@ -1,0 +1,22 @@
+function solution(citations) {
+  let answer = 0;
+  citations.sort((a, b) => {
+    return a - b;
+  });
+  let max = citations.at(-1);
+  while(answer <= max){
+    let num = 0;
+    for(let i = 0; i < citations.length; i++) {
+      if(answer <= citations[i]) {
+        num++;
+      }
+    }
+    if(num < answer) {
+      break;
+    }
+    answer++;
+
+  }
+  return answer - 1;
+}
+console.log(solution([3, 0, 6, 1, 5, 2]));


### PR DESCRIPTION
```javascript
function solution(arr)
{
    var answer = [];
    for(let i of arr) {
        if(answer.at(-1) != i) {
            answer.push(i)
        }
    }
    return answer;
}
```
위의 방식으로 문제를 풀었더니 답은 맞는데 시간 초과가 발생했다.
이유를 생각해보니 answer의 끝을 계속 확인하게 알고리즘을 만들었는데 answer배열이 length가 길어지면 끝 원소를
확인하는 시간이 오래걸린다는 생각을 하여서 아래와 같이 코드를 변경했다.
```javascript
function solution(arr)
{
  let answer = [];
  for(let i = 0; i < arr.length; i++) {
      if(arr[i] !== arr[i + 1]) {
          answer.push(arr[i]);
      }
  }
  return answer;
}
```
이 코드는 arr 배열의 한 뒤 원소를 비교해서 다르면 answer 배열에 push를 하였고
arr의 마지막 원소를 비교할 때 그 다음 원소는 undefined가 나와서 무조건 다르게 되므로
이렇게 문제를 해결했다.

```javascript
function solution(progresses, speeds) {
  let answer = [];
  for(let i = 0; i < progresses.length; i++) {
    let sum = progresses[i];
    let count = 0;
    while(sum < 100) {
      sum += speeds[i];
      count++;
    }
    answer.push(count);
  }
  let count = 1;
  let correct = [];
  let max = answer[0];
  for(let i = 1; i < answer.length; i++) {
    if(answer[i] <= max) {
      count++;
    } else {
      correct.push(count);
      count = 1;
      max = answer[i];
    }
  }
  correct.push(count);
  return correct;
}

console.log(solution([93, 30, 55], 	[1, 30, 5]));
```
위의 코드는 answer 배열에 합이 100이 이상이 될때까지 speed[i]를 더한 횟수를 push했다.
answer 배열의  첫 번째 원소를 max에 넣고 answer 배열의 원소를 비교하면서 answer[i]가
max 보다 작거나 같으면 count를 하나씩 늘리고 크면 count를 push하고 count를 1로 초기화 시키고
max에 answer[i]를 할당했다. 마지막 원소에 해당하는 count를 push하기 위해서 return 문 이전에
count를 push 했다.